### PR TITLE
Create GitHub release with binaries when pushing tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,12 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+    tags: [ "*" ]
   pull_request:
     branches: [ "main" ]
   merge_group:
+
+permissions: read-all
 
 jobs:
   build:
@@ -46,3 +49,22 @@ jobs:
         name: ${{ matrix.build }}
         path: target/debian/*.deb
         if-no-files-found: error
+  
+  release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            az-pim
+            az-pim.exe
+            *.deb


### PR DESCRIPTION
The release is created as draft and has to be manually published. If that's too much overhead it could also be made non-draft. 