### PR TITLE
add X-Ms-Command-Name header to requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ impl PimClient {
             .client
             .request(method, url)
             .query(&[("api-version", "2020-10-01")])
+            .header("X-Ms-Command-Name", "Microsoft_Azure_PIMCommon.")
             .bearer_auth(&self.token);
 
         if let Some(query) = query {


### PR DESCRIPTION
In practice, this appears to reduce some of the flakiness of listing active assignments and is in use by the Azure Portal.