### PR TITLE
fit interactive content to terminal width and add scrollbar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_client_core",
@@ -192,6 +193,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -1536,6 +1538,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1554,12 +1557,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -1944,6 +1949,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -1967,6 +1973,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2094,9 +2113,11 @@ dependencies = [
  "futures",
  "pin-project",
  "rand",
+ "reqwest",
  "serde",
  "serde_json",
  "time",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_macros",
@@ -2300,6 +2321,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ default-run = "az-pim"
 [dependencies]
 anyhow = { version ="1.0", default-features = false, features = ["std"] }
 azure-identity-helpers = { version = "0.0.17", default-features = false }
-azure_core = { version = "0.35", default-features = false }
-azure_identity = { version = "0.35", default-features = false }
+azure_core = { version = "0.35", default-features = false, features = ["reqwest", "tokio"] }
+azure_identity = { version = "0.35", default-features = false, features = ["tokio"] }
 base64 = { version = "0.22", default-features = false }
 clap = { version = "4.6", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "color", "suggestions"] }
 clap_complete = { version = "4.6", default-features = false }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -12,7 +12,8 @@ use ratatui::{
     },
     prelude::*,
     widgets::{
-        Block, BorderType, HighlightSpacing, Paragraph, Row, ScrollbarState, Table, TableState,
+        Block, BorderType, Cell, HighlightSpacing, Paragraph, Row, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, Table, TableState,
     },
 };
 use std::{collections::BTreeSet, io::stdout};
@@ -24,7 +25,12 @@ const JUSTIFICATION_TEXT: &str = "Type to enter justification";
 const SCOPE_TEXT: &str = "↑ or ↓ to move | Space to toggle";
 const DURATION_TEXT: &str = "↑ or ↓ to update duration";
 const ALL_HELP: &str = "Tab or Shift-Tab to change sections | Enter to activate | Esc to quit";
-const ITEM_HEIGHT: u16 = 2;
+const MIN_ITEM_HEIGHT: u16 = 2;
+// Width occupied by table chrome inside the bordered block:
+// 2 for borders + 1 leading pad + 4 for the highlight spacing column ("  > ").
+const SCOPES_CHROME: u16 = 7;
+// Minimum width we will allocate to either column before falling back.
+const MIN_COL_WIDTH: u16 = 8;
 
 pub struct Selected {
     pub assignments: BTreeSet<RoleAssignment>,
@@ -71,7 +77,7 @@ impl App {
             table_state: TableState::default().with_selected(0),
             justification,
             longest_item_lens: column_widths(&assignments)?,
-            scroll_state: ScrollbarState::new((assignments.len() - 1) * usize::from(ITEM_HEIGHT)),
+            scroll_state: ScrollbarState::new(assignments.len().saturating_sub(1)),
             items: assignments
                 .into_iter()
                 .map(|value| Entry {
@@ -103,7 +109,7 @@ impl App {
             None => 0,
         };
         self.table_state.select(Some(i));
-        self.scroll_state = self.scroll_state.position(i * usize::from(ITEM_HEIGHT));
+        self.scroll_state = self.scroll_state.position(i);
     }
 
     pub fn previous(&mut self) {
@@ -118,7 +124,7 @@ impl App {
             None => 0,
         };
         self.table_state.select(Some(i));
-        self.scroll_state = self.scroll_state.position(i * usize::from(ITEM_HEIGHT));
+        self.scroll_state = self.scroll_state.position(i);
     }
 
     fn check(&mut self) {
@@ -249,45 +255,85 @@ impl App {
     }
 
     fn render_scopes(&mut self, frame: &mut Frame, area: Rect) {
-        frame.render_stateful_widget(
-            Table::new(
-                self.items.iter().map(|data| {
-                    Row::new(vec![
-                        format!(
-                            "{} {}",
-                            if data.enabled { ENABLED } else { DISABLED },
-                            data.value.role
-                        ),
-                        if let Some(scope_name) = data.value.scope_name.as_deref() {
-                            format!("{scope_name}\n{}", data.value.scope)
-                        } else {
-                            data.value.scope.to_string()
-                        },
-                    ])
-                    .height(ITEM_HEIGHT)
-                }),
-                [
-                    Constraint::Length(self.longest_item_lens.0 + 4),
-                    Constraint::Min(self.longest_item_lens.1 + 1),
-                ],
+        // Carve up the area between the role and scope columns based on the
+        // current terminal width, so long scope paths don't get silently
+        // truncated on a normal-width terminal.
+        let inner_w = area.width.saturating_sub(SCOPES_CHROME);
+        let role_desired = self.longest_item_lens.0.saturating_add(4);
+        let scope_desired = self.longest_item_lens.1.saturating_add(1);
+
+        let (role_w, scope_w) = if role_desired.saturating_add(scope_desired) <= inner_w {
+            (
+                role_desired,
+                inner_w.saturating_sub(role_desired).max(MIN_COL_WIDTH),
             )
-            .header(
-                ["Role", "Scope"]
-                    .into_iter()
-                    .collect::<Row>()
-                    .style(Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED))
-                    .height(1),
-            )
-            .row_highlight_style(if self.input_state == InputState::Scopes {
-                Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            // Cap the role column at ~40% so the scope path always has room.
+            let cap = (inner_w * 2 / 5).max(MIN_COL_WIDTH);
+            let role = role_desired.min(cap).max(MIN_COL_WIDTH);
+            let scope = inner_w.saturating_sub(role).max(MIN_COL_WIDTH);
+            (role, scope)
+        };
+
+        let rows = self.items.iter().map(|data| {
+            let role_text = format!(
+                "{} {}",
+                if data.enabled { ENABLED } else { DISABLED },
+                data.value.role
+            );
+            let scope_text = if let Some(scope_name) = data.value.scope_name.as_deref() {
+                format!("{scope_name}\n{}", data.value.scope)
             } else {
-                Style::default()
-            })
-            .highlight_spacing(HighlightSpacing::Always)
-            .block(Block::bordered().title("Scopes")),
+                data.value.scope.to_string()
+            };
+
+            let role_lines = wrap_text(&role_text, role_w);
+            let scope_lines = wrap_text(&scope_text, scope_w);
+            let height = u16::try_from(role_lines.len().max(scope_lines.len()))
+                .unwrap_or(MIN_ITEM_HEIGHT)
+                .max(MIN_ITEM_HEIGHT);
+
+            Row::new(vec![
+                Cell::from(role_lines.join("\n")),
+                Cell::from(scope_lines.join("\n")),
+            ])
+            .height(height)
+        });
+
+        frame.render_stateful_widget(
+            Table::new(rows, [Constraint::Length(role_w), Constraint::Min(scope_w)])
+                .header(
+                    ["Role", "Scope"]
+                        .into_iter()
+                        .collect::<Row>()
+                        .style(Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED))
+                        .height(1),
+                )
+                .row_highlight_style(if self.input_state == InputState::Scopes {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                })
+                .highlight_spacing(HighlightSpacing::Always)
+                .block(Block::bordered().title("Scopes")),
             area,
             &mut self.table_state,
         );
+
+        // Always show a scrollbar so users know whether more rows exist
+        // off-screen. Render it inside the bordered block on the right edge.
+        if self.items.len() > 1 {
+            frame.render_stateful_widget(
+                Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                    .begin_symbol(Some("▲"))
+                    .end_symbol(Some("▼")),
+                area.inner(Margin {
+                    vertical: 1,
+                    horizontal: 0,
+                }),
+                &mut self.scroll_state,
+            );
+        }
     }
 
     fn render_footer(&self, f: &mut Frame, area: Rect) {
@@ -413,4 +459,78 @@ fn column_widths(items: &BTreeSet<RoleAssignment>) -> Result<(u16, u16)> {
         role_len.try_into()?,
         scope_name_len.max(scope_len).try_into()?,
     ))
+}
+
+/// Wrap `text` to lines no wider than `width` columns, breaking on whitespace
+/// where possible and falling back to hard breaks for long unbroken runs (such
+/// as Azure scope paths).
+fn wrap_text(text: &str, width: u16) -> Vec<String> {
+    let width = usize::from(width.max(1));
+    let mut out = Vec::new();
+    for line in text.split('\n') {
+        if line.is_empty() {
+            out.push(String::new());
+            continue;
+        }
+        let mut current = String::new();
+        for word in line.split_inclusive(char::is_whitespace) {
+            if current.chars().count() + word.chars().count() <= width {
+                current.push_str(word);
+                continue;
+            }
+            if !current.is_empty() {
+                out.push(std::mem::take(&mut current));
+            }
+            // Hard-break any single token longer than the column width.
+            let mut chunk = String::new();
+            for ch in word.chars() {
+                if chunk.chars().count() == width {
+                    out.push(std::mem::take(&mut chunk));
+                }
+                chunk.push(ch);
+            }
+            current = chunk;
+        }
+        out.push(current);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrap_text;
+
+    #[test]
+    fn wrap_short_text_unchanged() {
+        assert_eq!(wrap_text("hello", 80), vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn wrap_breaks_on_whitespace() {
+        assert_eq!(
+            wrap_text("one two three four", 8),
+            vec![
+                "one two ".to_string(),
+                "three ".to_string(),
+                "four".to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn wrap_hard_breaks_long_token() {
+        let scope = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg";
+        let wrapped = wrap_text(scope, 20);
+        assert!(wrapped.iter().all(|l| l.chars().count() <= 20));
+        assert_eq!(wrapped.concat(), scope);
+    }
+
+    #[test]
+    fn wrap_preserves_explicit_newlines() {
+        let wrapped = wrap_text("name\n/path/to/scope", 40);
+        assert_eq!(
+            wrapped,
+            vec!["name".to_string(), "/path/to/scope".to_string()]
+        );
+    }
 }


### PR DESCRIPTION
The `activate interactive` UI previously sized the Scopes table to the longest role/scope strings it had data for, so on a normal-width terminal long Azure scope paths were silently truncated and there was no indication that more rows existed off-screen.

### Changes

- **Width-aware columns**: compute column widths from `area.width`. When everything fits, behavior is unchanged; otherwise the role column is capped at ~40% and the scope column gets the rest, with sane minimums.
- **Wrapping**: a small `wrap_text` helper word-wraps cell contents and hard-breaks any single token longer than the column (so scope paths wrap instead of getting cut off). Each row's height grows to fit the wrapped content.
- **Scrollbar**: render a `▲`/`▼` vertical scrollbar on the right edge of the Scopes pane (only when there's more than one row) so users can see both their position and that more rows exist off-screen.
- **HTTP client wiring**: `azure_core` 0.35 ships a panicking `NoopClient` and only wires up reqwest when the `reqwest` feature is enabled. Since this crate sets `default-features = false`, that feature was off and the first real HTTP call (e.g. device-code login) panicked. Added `features = ["reqwest", "tokio"]` on `azure_core` and `features = ["tokio"]` on `azure_identity`. No TLS backend feature is forced — `reqwest` is still configured with `native-tls` as before.

### Tests

- Added unit tests for `wrap_text` (short text passthrough, whitespace wrapping, hard-breaks on long Azure-style paths, and preservation of explicit newlines).
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --lib interactive` all pass.